### PR TITLE
Validator Fix

### DIFF
--- a/philips-airjs.html
+++ b/philips-airjs.html
@@ -4,7 +4,7 @@
         color: '#ff7f00',
         defaults: {
             name: {value:'philips-airjs'},
-            host: {value: "", validate:RED.validators.required }
+            host: {value: "", validate:RED.validators.regex(/^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)+([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$/) }
         },
         inputs:1,
         outputs:1,


### PR DESCRIPTION
With Node-Red 3.x and NodeJS 16.x I get a validator undefined error.

I modified the Validator to use regex and only accept IPs and Hostnames. Not only checking if "empty".